### PR TITLE
add option to promote interface props/fields to function parameter

### DIFF
--- a/src/main/bin/resolveOptions.ts
+++ b/src/main/bin/resolveOptions.ts
@@ -104,6 +104,12 @@ export function resolveOptions(args: Array<string>): IMakeOptions {
                 index += 1
                 break
 
+            case '--functionsFieldPromotion':
+                options.functionFieldPromotion.typeName = args[index + 1]
+                options.functionFieldPromotion.isEnabled = true
+                index += 2
+                break
+
             default:
                 if (next.startsWith('--')) {
                     throw new Error(

--- a/src/main/defaults.ts
+++ b/src/main/defaults.ts
@@ -1,4 +1,4 @@
-import { IMakeOptions } from './types'
+import { IFunctionFieldPromote, IMakeOptions } from './types'
 import { deepMerge } from './utils'
 
 export const DEFAULT_APACHE_LIB = 'thrift'
@@ -18,6 +18,7 @@ export const DEFAULT_OPTIONS: IMakeOptions = {
     withNameField: false,
     omitProtocolReaders: false,
     omitThriftLibImport: false,
+    functionFieldPromotion: {isEnabled: false} as IFunctionFieldPromote,
     useInterfacesWithFunctions: false,
     useStringLiteralsForEnums: false,
 }

--- a/src/main/render/apache/function.ts
+++ b/src/main/render/apache/function.ts
@@ -2,12 +2,14 @@ import * as ts from 'typescript'
 
 import {
     FieldDefinition,
+    Identifier,
     InterfaceWithFields,
 } from '@creditkarma/thrift-parser'
 
 import { IRenderState } from '../../types'
 import { createArgsParameterForStruct } from './struct'
 import { renderValue } from './values'
+import { createFunctionParameter } from './utils'
 
 export function functionNameForClass(statement: InterfaceWithFields): string {
     return `create${statement.name.value}`
@@ -29,9 +31,15 @@ function interfaceConstruction(
                                       field.defaultValue,
                                       state,
                                   )
-                                : ts.createIdentifier(
-                                      `args.${field.name.value}`,
-                                  )
+                                : ( state.options.functionFieldPromotion.isEnabled
+                                    && (field.fieldType as Identifier).value == state.options.functionFieldPromotion.typeName
+                                    ? ts.createIdentifier(
+                                        state.options.functionFieldPromotion.paramName
+                                        )
+                                    : ts.createIdentifier(
+                                        `args.${field.name.value}`,
+                                        )
+                                )
                         return ts.createPropertyAssignment(
                             ts.createIdentifier(field.name.value),
                             defaultValue,
@@ -49,13 +57,30 @@ export function renderFunction(
     statement: InterfaceWithFields,
     state: IRenderState,
 ): ts.FunctionDeclaration {
+    var paramSet = createArgsParameterForStruct(statement);
+    if (state.options.functionFieldPromotion.isEnabled) {
+        var promoteField = statement.fields.find((field) => {
+            return (field.fieldType as Identifier).value == state.options.functionFieldPromotion.typeName;
+        })
+
+        if (promoteField) {
+            paramSet.push(
+                createFunctionParameter(
+                    state.options.functionFieldPromotion.paramName, // param name
+                    ts.createTypeReferenceNode(state.options.functionFieldPromotion.qualifiedTypeName, undefined), // param type
+                    undefined, // initializer
+                    false // optional?
+                )
+            );
+        }
+    }
     return ts.createFunctionDeclaration(
         undefined,
         [ts.createToken(ts.SyntaxKind.ExportKeyword)],
         undefined,
         functionNameForClass(statement),
         undefined,
-        createArgsParameterForStruct(statement),
+        paramSet,
         ts.createTypeReferenceNode(statement.name.value, undefined),
         interfaceConstruction(statement, state),
     )

--- a/src/main/render/apache/interface.ts
+++ b/src/main/render/apache/interface.ts
@@ -2,6 +2,7 @@ import * as ts from 'typescript'
 
 import {
     FieldDefinition,
+    Identifier,
     InterfaceWithFields,
 } from '@creditkarma/thrift-parser'
 
@@ -46,6 +47,22 @@ export function renderInterface(
         fields = fields.filter((field: FieldDefinition) => {
             return field.defaultValue == null
         })
+        if (state.options.functionFieldPromotion.isEnabled) {
+            var promoteField = fields.find((field: FieldDefinition) => {
+                return (field.fieldType as Identifier).value == state.options.functionFieldPromotion.typeName
+            })
+            if (promoteField) {
+                // cache properties for field we're promoting
+                state.options.functionFieldPromotion.fieldName = promoteField.name.value;
+                state.options.functionFieldPromotion.paramName = promoteField.name.value.charAt(0).toLowerCase() + promoteField.name.value.slice(1);
+                state.options.functionFieldPromotion.qualifiedTypeName = state.options.functionFieldPromotion.typeName + '.' + state.options.functionFieldPromotion.typeName;
+
+                // args should also exclude promotion fields
+                fields = fields.filter((field: FieldDefinition) => {
+                    return field != promoteField
+                })
+            }
+        }
     }
 
     const signatures = fields.map((field: FieldDefinition) => {

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -165,11 +165,31 @@ export interface IMakeOptions {
     // Omit thrift library imports
     omitThriftLibImport: boolean
 
+    // promote a function field to a function parameter
+    functionFieldPromotion: IFunctionFieldPromote
+
     // replace classes with interfaces + functions
     useInterfacesWithFunctions: boolean
 
     // replace enum int values with string literals
     useStringLiteralsForEnums: boolean
+}
+
+export interface IFunctionFieldPromote {
+    // whether the option is enabled
+    isEnabled: boolean
+
+    // the name of the field in the interface functions
+    fieldName: string
+
+    // the name to give the parameter
+    paramName: string
+
+    // the name of the field type
+    typeName: string
+
+    // the qualified name of the field type (file.typeName)
+    qualifiedTypeName: string
 }
 
 export interface IThriftFiles {


### PR DESCRIPTION
These changes were requested to help reduce overhead when binding to structs' generated *Args interfaces.

A package cmd line option param was added which will optionally exclude a given field/property type-name from the typescript generated Args interface and also change the signature of the generated function by promoting that property as a separate function parameter (because the property will no longer be contained in the Args object function parameter).

This new option is only applicable when --useInterfacesWithFunctions param is also passed in.

Example, when passing the below param and property type-name, if a Args interface includes this property then it would be excluded from Args and promoted to be a parameter in the associated function definition.
--functionsFieldPromotion UTCommonHVAProperties